### PR TITLE
Enable specifying radius per corner, simplified some statements

### DIFF
--- a/src/androidTest/kotlin/group/infotech/drawable/dsl/SnapshotTest.kt
+++ b/src/androidTest/kotlin/group/infotech/drawable/dsl/SnapshotTest.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
+import android.util.Log
 import group.infotech.drawable.dsl.test.R
 import io.kotlintest.matchers.should
 import org.jetbrains.anko.dip
@@ -143,5 +144,20 @@ class SnapshotTest {
         )
 
     dsl should drawPixelsLike(ctx.drawable(R.drawable.layers))
+  }
+
+  @Test
+  fun corners() {
+
+    val dsl = shapeDrawable {
+      shape = GradientDrawable.RECTANGLE
+      corners (10f){
+        topLeft = 15f
+        bottomRight = 5f
+      }
+      solidColor = Color.parseColor("#666666")
+    }
+
+    dsl should drawPixelsLike(ctx.drawable(R.drawable.corners))
   }
 }

--- a/src/androidTest/res/drawable/corners.xml
+++ b/src/androidTest/res/drawable/corners.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:radius="10px"
+        android:topLeftRadius="15px"
+        android:bottomRightRadius="5px" />
+    <solid android:color="#666666" />
+</shape>

--- a/src/main/kotlin/group/infotech/drawable/dsl/drawable-dsl.kt
+++ b/src/main/kotlin/group/infotech/drawable/dsl/drawable-dsl.kt
@@ -16,9 +16,9 @@ typealias Milliseconds = Int
 typealias GravityInt = Int
 
 inline fun scaleDrawable(scale: Float, gravity: GravityInt = Gravity.CENTER, block: () -> Drawable): ScaleDrawable =
-    ScaleDrawable(block(), gravity, scale, scale).also {
+    ScaleDrawable(block(), gravity, scale, scale).apply {
       // hacking dem android drawables
-      it.level = 1
+      level = 1
     }
 
 @TargetApi(21)

--- a/src/main/kotlin/group/infotech/drawable/dsl/shapes.kt
+++ b/src/main/kotlin/group/infotech/drawable/dsl/shapes.kt
@@ -101,3 +101,20 @@ inline fun GradientDrawable.size(fill: Size.() -> Unit) =
       fill()
       setSize(width, height)
     }
+
+class Corners(all: FloatPx) {
+  var topLeft: FloatPx = all
+  var topRight: FloatPx = all
+  var bottomLeft: FloatPx = all
+  var bottomRight: FloatPx = all
+}
+
+inline fun GradientDrawable.corners(all: FloatPx, fill: Corners.() -> Unit) =
+    Corners(all).apply {
+      cornerRadius = all
+      fill()
+      if (topLeft != all || topRight != all || bottomLeft != all || bottomRight != all)
+        cornerRadii = floatArrayOf(topLeft, topLeft, topRight, topRight, bottomRight, bottomRight, bottomLeft, bottomLeft)
+    }
+
+inline fun GradientDrawable.corners(fill: Corners.() -> Unit) = corners(0f, fill)

--- a/src/main/kotlin/group/infotech/drawable/dsl/shapes.kt
+++ b/src/main/kotlin/group/infotech/drawable/dsl/shapes.kt
@@ -4,9 +4,9 @@ import android.annotation.TargetApi
 import android.graphics.drawable.GradientDrawable
 
 inline fun shapeDrawable(block: GradientDrawable.() -> Unit): GradientDrawable =
-    GradientDrawable().also {
-      it.gradientType = GradientDrawable.LINEAR_GRADIENT
-      it.block()
+    GradientDrawable().apply {
+      gradientType = GradientDrawable.LINEAR_GRADIENT
+      block()
     }
 
 enum class Shape {
@@ -85,11 +85,10 @@ class Stroke {
   var dashGap: FloatPx = 0F
 }
 
-inline fun <T> GradientDrawable.stroke(fill: Stroke.() -> T): T =
-    Stroke().let { s ->
-      s.fill().also {
-        setStroke(s.width, s.color, s.dashWidth, s.dashGap)
-      }
+inline fun GradientDrawable.stroke(fill: Stroke.() -> Unit) =
+    Stroke().apply {
+      fill()
+      setStroke(width, color, dashWidth, dashGap)
     }
 
 class Size {
@@ -97,9 +96,8 @@ class Size {
   var height: Px = -1
 }
 
-inline fun <T> GradientDrawable.size(fill: Size.() -> T): T =
-    Size().let { s ->
-      s.fill().also {
-        setSize(s.width, s.height)
-      }
+inline fun GradientDrawable.size(fill: Size.() -> Unit) =
+    Size().apply {
+      fill()
+      setSize(width, height)
     }


### PR DESCRIPTION
Specifying the per-corner radiuses like in xml example is really verbose and tricky, with all of this calls to `setCornerRadii(floatArray!)`, and leads to duplicating code. But it is history now ;)
```xml
<shape xmlns:android="http://schemas.android.com/apk/res/android"
    android:shape="rectangle">
    <corners
        android:radius="10px"
        android:topLeftRadius="15px"
        android:bottomRightRadius="5px" />
    <solid android:color="#666666" />
</shape>
```
Now corresponds to
```kotlin
shapeDrawable {
      shape = GradientDrawable.RECTANGLE
      corners (10f) {
        topLeft = 15f
        bottomRight = 5f
      }
      solidColor = Color.parseColor("#666666")
    }
```
